### PR TITLE
Update Readme & small fix to test/example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-worker-pouch [![Build Status](https://travis-ci.org/nolanlawson/worker-pouch.svg)](https://travis-ci.org/nolanlawson/worker-pouch)
+worker-pouch [![Build Status](https://travis-ci.org/pouchdb-community/worker-pouch.svg)](https://travis-ci.org/pouchdb-community/worker-pouch)
 =====
 
 ```js
@@ -158,7 +158,7 @@ navigator.serviceWorker.register('sw.js', {
       db = new PouchDB('testdb', {
         adapter: 'worker',
         worker: function() {
-          return serviceWorker;
+          return serviceWorker.controller;
         }
       });
       return db;

--- a/test/custom-api/service-worker-test.js
+++ b/test/custom-api/service-worker-test.js
@@ -30,7 +30,7 @@ describe('Service Worker custom api test suite', function () {
       db = new PouchDB('testdb', {
         adapter: 'worker',
         worker: function() {
-          return serviceWorker;
+          return serviceWorker.controller;
         }
       });
       return db;


### PR DESCRIPTION
* Updated TravisCI to point to the new organization
* The configuration object expects a SW but `serviceWorker` was a
SWContainer in both Chrome and FF on my MacBook. If this was a bug; it’s fixed. If this
is not a bug in all environments, then PouchDB’s constructor may need
to be adjusted to detect either a SW or a SWC and, if a SWC, get the
SW automagically.