### PR TITLE
Use _interopDefault on require('pouchdb-promise')

### DIFF
--- a/lib/client/is-supported-browser.js
+++ b/lib/client/is-supported-browser.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var Promise = require('pouchdb-promise');
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var Promise = _interopDefault(require('pouchdb-promise'));
 var createWorker = require('./create-worker');
 
 module.exports = function isSupportedBrowser() {

--- a/lib/client/is-supported-browser.js
+++ b/lib/client/is-supported-browser.js
@@ -1,6 +1,8 @@
 'use strict';
 
-function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+function _interopDefault (ex) {
+  return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex;
+}
 
 var Promise = _interopDefault(require('pouchdb-promise'));
 var createWorker = require('./create-worker');

--- a/lib/shared/utils.js
+++ b/lib/shared/utils.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var Promise = require('pouchdb-promise');
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var Promise = _interopDefault(require('pouchdb-promise'));
 
 exports.lastIndexOf = function lastIndexOf(str, char) {
   for (var i = str.length - 1; i >= 0; i--) {

--- a/lib/shared/utils.js
+++ b/lib/shared/utils.js
@@ -1,6 +1,8 @@
 'use strict';
 
-function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+function _interopDefault (ex) {
+  return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex;
+}
 
 var Promise = _interopDefault(require('pouchdb-promise'));
 

--- a/lib/worker/core.js
+++ b/lib/worker/core.js
@@ -2,7 +2,9 @@
 
 /* jshint worker:true */
 
-var Promise = require('pouchdb-promise');
+function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+
+var Promise = _interopDefault(require('pouchdb-promise'));
 var errors = require('../shared/errors');
 var workerUtils = require('./utils');
 var decodeArgs = workerUtils.decodeArgs;

--- a/lib/worker/core.js
+++ b/lib/worker/core.js
@@ -2,7 +2,9 @@
 
 /* jshint worker:true */
 
-function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
+function _interopDefault (ex) {
+  return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex;
+}
 
 var Promise = _interopDefault(require('pouchdb-promise'));
 var errors = require('../shared/errors');


### PR DESCRIPTION
My project uses:
- webpack 2.5.1
- worker-pouch 2.0.0
- pouchdb-promise and all other pouchdb core modules 6.3.4

The build result makes use of `lib/index.es.js` (instead of lib/index.js) from `pouchdb-promise`:
```javascript
import lie from 'lie';

/* istanbul ignore next */
var PouchPromise = typeof Promise === 'function' ? Promise : lie;

export default PouchPromise;
```
When `worker-pouch/lib/client/is-supported-browser.js` requires `pouchdb-promise`, it obtains an object containing a `default` property which is the real `PouchPromise`. 
This leads to an exception at runtime about `missing resolve property in target Promise`.

`pouchdb` core modules use an `_interopDefault` function that is missing from `worker-pouch`.

This PR adds this function to require `pouchdb-promise` via `_interopDefault`.